### PR TITLE
fix: able to add models with contact point as uri resource

### DIFF
--- a/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
+++ b/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
@@ -37,15 +37,21 @@ class RDFUtils {
 
     @Test
     fun createDatasetModel() {
-        val harvestedModel = responseReader.parseFile("harvest_response.ttl", "TURTLE")
-        val expected = responseReader.parseFile("harvested_dataset.ttl", "TURTLE")
+        val harvestedModel0 = responseReader.parseFile("harvest_response.ttl", "TURTLE")
+        val expected0 = responseReader.parseFile("harvested_dataset.ttl", "TURTLE")
+        val harvestedModel1 = responseReader.parseFile("harvest_response_1.ttl", "TURTLE")
+        val expected1 = responseReader.parseFile("harvested_dataset_1.ttl", "TURTLE")
 
-        val datasetResource = harvestedModel.listResourcesWithProperty(RDF.type, DCAT.Dataset)
-            .toList().first()
+        val datasetModel0 = harvestedModel0
+            .listResourcesWithProperty(RDF.type, DCAT.Dataset)
+            .toList().first().createDatasetModel()
 
-        val datasetModel = datasetResource.createDatasetModel()
+        val datasetModel1 = harvestedModel1
+            .listResourcesWithProperty(RDF.type, DCAT.Dataset)
+            .toList().first().createDatasetModel()
 
-        Assertions.assertTrue(datasetModel.isIsomorphicWith(expected))
+        Assertions.assertTrue(datasetModel0.isIsomorphicWith(expected0))
+        Assertions.assertTrue(datasetModel1.isIsomorphicWith(expected1))
     }
 
 }

--- a/src/test/resources/harvest_response_1.ttl
+++ b/src/test/resources/harvest_response_1.ttl
@@ -1,0 +1,46 @@
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+<https://testdirektoratet.no/model/dataset/1>
+        a                         dcat:Dataset ;
+        dct:accessRights          <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description           "Description of dataset 0"@nb ;
+        dct:identifier            "adb4cf00-31c8-460c-9563-55f204cf8221" ;
+        dct:title                 "Dataset 0"@nb ;
+        dcat:contactPoint         <https://testdirektoratet.no/model/contact/1> ;
+        dcat:endpointDescription  <https://testdirektoratet.no/openapi/dataset/1.yaml> ;
+        dct:issued                "2019-03-22T13:11:16.546902"^^xsd:dateTime ;
+        dct:language              <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:temporal              <https://testdirektoratet.no/model/periodoftime/1> ;
+        dcat:distribution         [ a                   dcat:Distribution ;
+                                    dct:format          "CSV JSON JSONP YAML XML" ;
+                                    dct:license         <https://data.norge.no/nlod/no> ;
+                                    dct:title           "Test distribution 1" ;
+                                    dcat:accessURL      <http://testdirektoratet.no/data/test/1> ] ,
+                                  [ a                   dcat:Distribution ;
+                                    dct:format          "CSV JSON JSONP YAML XML" ;
+                                    dct:license         <https://data.norge.no/nlod/no> ;
+                                    dct:title           "Test distribution 2" ;
+                                    dcat:accessURL      <http://testdirektoratet.no/data/test/2> ] ;
+        dcat:keyword              "test", "fest" ;
+        dcat:theme                <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
+                                  <http://publications.europa.eu/resource/authority/data-theme/TECH> ;
+        foaf:page                 <https://testdirektoratet.no> .
+
+<https://testdirektoratet.no/model/dataset-catalog/1>
+        a              dcat:Catalog ;
+        dct:publisher  <https://organization-catalogue.fellesdatakatalog.brreg.no/organizations/123456789> ;
+        dct:title      "Datasettkatalog for Testdirektoratet"@nb ;
+        dcat:dataset   <https://testdirektoratet.no/model/dataset/1> .
+
+<https://testdirektoratet.no/model/contact/1>
+        a                          vcard:Organization ;
+        vcard:hasOrganizationName  "Testdirektoratet"@nb ;
+        vcard:hasURL               <https://testdirektoratet.no> .
+
+<https://testdirektoratet.no/model/periodoftime/1>
+        a                 dct:PeriodOfTime ;
+        dcat:startDate    "2019-04-02T00:00:00"^^xsd:dateTime .

--- a/src/test/resources/harvested_dataset_1.ttl
+++ b/src/test/resources/harvested_dataset_1.ttl
@@ -1,0 +1,40 @@
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dcat:  <http://www.w3.org/ns/dcat#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+<https://testdirektoratet.no/model/dataset/1>
+        a                         dcat:Dataset ;
+        dct:accessRights          <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
+        dct:description           "Description of dataset 0"@nb ;
+        dct:identifier            "adb4cf00-31c8-460c-9563-55f204cf8221" ;
+        dct:title                 "Dataset 0"@nb ;
+        dcat:contactPoint         <https://testdirektoratet.no/model/contact/1> ;
+        dcat:endpointDescription  <https://testdirektoratet.no/openapi/dataset/1.yaml> ;
+        dct:issued                "2019-03-22T13:11:16.546902"^^xsd:dateTime ;
+        dct:language              <http://publications.europa.eu/resource/authority/language/NOR> ;
+        dct:temporal              <https://testdirektoratet.no/model/periodoftime/1> ;
+        dcat:distribution         [ a                   dcat:Distribution ;
+                                    dct:format          "CSV JSON JSONP YAML XML" ;
+                                    dct:license         <https://data.norge.no/nlod/no> ;
+                                    dct:title           "Test distribution 1" ;
+                                    dcat:accessURL      <http://testdirektoratet.no/data/test/1> ] ,
+                                  [ a                   dcat:Distribution ;
+                                    dct:format          "CSV JSON JSONP YAML XML" ;
+                                    dct:license         <https://data.norge.no/nlod/no> ;
+                                    dct:title           "Test distribution 2" ;
+                                    dcat:accessURL      <http://testdirektoratet.no/data/test/2> ] ;
+        dcat:keyword              "test", "fest" ;
+        dcat:theme                <http://publications.europa.eu/resource/authority/data-theme/GOVE>,
+                                  <http://publications.europa.eu/resource/authority/data-theme/TECH> ;
+        foaf:page                 <https://testdirektoratet.no> .
+
+<https://testdirektoratet.no/model/contact/1>
+        a                          vcard:Organization ;
+        vcard:hasOrganizationName  "Testdirektoratet"@nb ;
+        vcard:hasURL               <https://testdirektoratet.no> .
+
+<https://testdirektoratet.no/model/periodoftime/1>
+        a                 dct:PeriodOfTime ;
+        dcat:startDate    "2019-04-02T00:00:00"^^xsd:dateTime .


### PR DESCRIPTION
Det er lov å legge til tilhørende resource som uri-resource, dvs linker til annet objekt i fila, og å barre legge det som et inline objekt. Støtter begge nå.

Se på forskjellen mellom testfilene 'harvested_dataset.ttl' og 'harvested_dataset_1.ttl' om jeg forklarer dårlig :+1: