### PR TITLE
fix: add service & stacktrace to error messages

### DIFF
--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/DatasetAdapter.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/DatasetAdapter.kt
@@ -1,5 +1,6 @@
 package no.digdir.informasjonsforvaltning.fdk_dataset_harvester.adapter
 
+import no.digdir.informasjonsforvaltning.fdk_dataset_harvester.harvester.HarvestException
 import no.digdir.informasjonsforvaltning.fdk_dataset_harvester.model.HarvestDataSource
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -19,7 +20,7 @@ class DatasetAdapter {
             connection.setRequestProperty("Accept", source.acceptHeaderValue)
 
             if (connection.responseCode != HttpStatus.OK.value()) {
-                LOGGER.error(Exception("Harvest from ${source.url} has failed").stackTraceToString())
+                LOGGER.error("Harvest from ${source.url} has failed", HarvestException(source.url ?: "undefined"))
                 null
             } else {
                 connection
@@ -29,7 +30,7 @@ class DatasetAdapter {
             }
 
         } catch (ex: Exception) {
-            LOGGER.error("${ex.stackTraceToString()}: Error when harvesting from ${source.url}")
+            LOGGER.error("Error when harvesting from ${source.url}", ex)
             null
         }
 

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/DatasetAdapter.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/DatasetAdapter.kt
@@ -19,7 +19,7 @@ class DatasetAdapter {
             connection.setRequestProperty("Accept", source.acceptHeaderValue)
 
             if (connection.responseCode != HttpStatus.OK.value()) {
-                LOGGER.error("Harvest from ${source.url} has failed")
+                LOGGER.error(Exception("Harvest from ${source.url} has failed").stackTraceToString())
                 null
             } else {
                 connection
@@ -29,7 +29,7 @@ class DatasetAdapter {
             }
 
         } catch (ex: Exception) {
-            LOGGER.error("Error when harvesting from ${source.url}: ${ex.message}")
+            LOGGER.error("${ex.stackTraceToString()}: Error when harvesting from ${source.url}")
             null
         }
 

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/HarvestAdminAdapter.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/HarvestAdminAdapter.kt
@@ -38,11 +38,11 @@ class HarvestAdminAdapter(private val applicationProperties: ApplicationProperti
                     val body = inputStream.bufferedReader().use(BufferedReader::readText)
                     return jacksonObjectMapper().readValue(body)
                 } else {
-                    logger.error(Exception("Fetch of harvest urls from $url failed, status: $responseCode").stackTraceToString())
+                    logger.error("Fetch of harvest urls from $url failed, status: $responseCode", Exception("Fetch of data sources failed"))
                 }
             }
         } catch (ex: Exception) {
-            logger.error("${ex.stackTraceToString()}: Error fetching harvest urls from $url")
+            logger.error("Error fetching harvest urls from $url", ex)
         }
         return emptyList()
     }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/HarvestAdminAdapter.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/adapter/HarvestAdminAdapter.kt
@@ -38,11 +38,11 @@ class HarvestAdminAdapter(private val applicationProperties: ApplicationProperti
                     val body = inputStream.bufferedReader().use(BufferedReader::readText)
                     return jacksonObjectMapper().readValue(body)
                 } else {
-                    logger.error("Fetch of harvest urls from $url failed, status: $responseCode")
+                    logger.error(Exception("Fetch of harvest urls from $url failed, status: $responseCode").stackTraceToString())
                 }
             }
         } catch (ex: Exception) {
-            logger.error("Error fetching harvest urls from $url", ex)
+            logger.error("${ex.stackTraceToString()}: Error fetching harvest urls from $url")
         }
         return emptyList()
     }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/DatasetHarvester.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/DatasetHarvester.kt
@@ -37,12 +37,12 @@ class DatasetHarvester(
         }
 
         when {
-            jenaWriterType == null -> LOGGER.error("Not able to harvest from ${source.url}, no accept header supplied")
-            jenaWriterType == Lang.RDFNULL -> LOGGER.error("Not able to harvest from ${source.url}, header ${source.acceptHeaderValue} is not acceptable ")
+            jenaWriterType == null -> LOGGER.error(Exception("Not able to harvest from ${source.url}, no accept header supplied").stackTraceToString())
+            jenaWriterType == Lang.RDFNULL -> LOGGER.error(Exception("Not able to harvest from ${source.url}, header ${source.acceptHeaderValue} is not acceptable ").stackTraceToString())
             harvested == null -> LOGGER.info("Not able to harvest ${source.url}")
             else -> updateIfChanged(harvested, source.url, harvestDate)
         }
-    } else LOGGER.error("Harvest source is not defined")
+    } else LOGGER.error(Exception("Harvest source is not defined").stackTraceToString())
 
     private fun updateIfChanged(harvested: Model, sourceURL: String, harvestDate: Calendar) {
         val dbData = turtleService.getHarvestSource(sourceURL)

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/DatasetHarvester.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/DatasetHarvester.kt
@@ -26,7 +26,7 @@ class DatasetHarvester(
 ) {
 
     fun harvestDatasetCatalog(source: HarvestDataSource, harvestDate: Calendar) =
-        if (source.url != null) {
+    if (source.url != null) {
         LOGGER.debug("Starting harvest of ${source.url}")
         val jenaWriterType = jenaTypeFromAcceptHeader(source.acceptHeaderValue)
 
@@ -37,12 +37,12 @@ class DatasetHarvester(
         }
 
         when {
-            jenaWriterType == null -> LOGGER.error(Exception("Not able to harvest from ${source.url}, no accept header supplied").stackTraceToString())
-            jenaWriterType == Lang.RDFNULL -> LOGGER.error(Exception("Not able to harvest from ${source.url}, header ${source.acceptHeaderValue} is not acceptable ").stackTraceToString())
+            jenaWriterType == null -> LOGGER.error("Not able to harvest from ${source.url}, no accept header supplied", HarvestException(source.url))
+            jenaWriterType == Lang.RDFNULL -> LOGGER.error("Not able to harvest from ${source.url}, header ${source.acceptHeaderValue} is not acceptable", HarvestException(source.url))
             harvested == null -> LOGGER.info("Not able to harvest ${source.url}")
             else -> updateIfChanged(harvested, source.url, harvestDate)
         }
-    } else LOGGER.error(Exception("Harvest source is not defined").stackTraceToString())
+    } else LOGGER.error("Harvest source is not defined", HarvestException("undefined"))
 
     private fun updateIfChanged(harvested: Model, sourceURL: String, harvestDate: Calendar) {
         val dbData = turtleService.getHarvestSource(sourceURL)

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvestHelpers.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvestHelpers.kt
@@ -98,3 +98,5 @@ data class DatasetModel (
     val resource: Resource,
     val harvestedDataset: Model
 )
+
+class HarvestException(url: String) : Exception("Harvest failed for $url")

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterActivity.kt
@@ -47,7 +47,7 @@ class HarvesterActivity(
                                     try {
                                         harvester.harvestDatasetCatalog(it, Calendar.getInstance())
                                     } catch (exception: Exception) {
-                                        LOGGER.error("Harvest of ${it.url} failed", exception)
+                                        LOGGER.error("${exception.stackTraceToString()}: Harvest of ${it.url} failed: ")
                                     }
                                 }
                             }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterActivity.kt
@@ -47,7 +47,7 @@ class HarvesterActivity(
                                     try {
                                         harvester.harvestDatasetCatalog(it, Calendar.getInstance())
                                     } catch (exception: Exception) {
-                                        LOGGER.error("${exception.stackTraceToString()}: Harvest of ${it.url} failed: ")
+                                        LOGGER.error("Harvest of ${it.url} failed", exception)
                                     }
                                 }
                             }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rabbit/RabbitMQPublisher.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rabbit/RabbitMQPublisher.kt
@@ -15,7 +15,7 @@ class RabbitMQPublisher(private val template: RabbitTemplate) {
             template.convertAndSend("harvests","datasets.harvester.UpdateSearchTrigger", UpdateSearchMessage(dbId))
             LOGGER.debug("Successfully sent UpdateSearchTrigger for $dbId")
         } catch (e: AmqpException) {
-            LOGGER.error("Could not trigger search update: ${e.message}")
+            LOGGER.error("${e.stackTraceToString()}: Could not trigger search update")
         }
     }
 
@@ -24,7 +24,7 @@ class RabbitMQPublisher(private val template: RabbitTemplate) {
             template.convertAndSend("updates", "assessments.update", "")
             LOGGER.debug("Successfully sent assessments.update message")
         } catch (e: AmqpException) {
-            LOGGER.error("Could not trigger assessments update", e)
+            LOGGER.error("${e.stackTraceToString()}: Could not trigger assessments update")
         }
     }
 }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rabbit/RabbitMQPublisher.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rabbit/RabbitMQPublisher.kt
@@ -15,7 +15,7 @@ class RabbitMQPublisher(private val template: RabbitTemplate) {
             template.convertAndSend("harvests","datasets.harvester.UpdateSearchTrigger", UpdateSearchMessage(dbId))
             LOGGER.debug("Successfully sent UpdateSearchTrigger for $dbId")
         } catch (e: AmqpException) {
-            LOGGER.error("${e.stackTraceToString()}: Could not trigger search update")
+            LOGGER.error("Could not trigger search update", e)
         }
     }
 
@@ -24,7 +24,7 @@ class RabbitMQPublisher(private val template: RabbitTemplate) {
             template.convertAndSend("updates", "assessments.update", "")
             LOGGER.debug("Successfully sent assessments.update message")
         } catch (e: AmqpException) {
-            LOGGER.error("${e.stackTraceToString()}: Could not trigger assessments update")
+            LOGGER.error("Could not trigger assessments update", e)
         }
     }
 }

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
@@ -47,7 +47,7 @@ fun parseRDFResponse(responseBody: String, rdfLanguage: Lang, rdfSource: String?
     try {
         responseModel.read(StringReader(responseBody), BACKUP_BASE_URI, rdfLanguage.name)
     } catch (ex: Exception) {
-        logger.error("${ex.stackTraceToString()}: Parse from $rdfSource has failed")
+        logger.error("Parse from $rdfSource has failed", ex)
         return null
     }
 

--- a/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/rdf/RDFUtils.kt
@@ -47,7 +47,7 @@ fun parseRDFResponse(responseBody: String, rdfLanguage: Lang, rdfSource: String?
     try {
         responseModel.read(StringReader(responseBody), BACKUP_BASE_URI, rdfLanguage.name)
     } catch (ex: Exception) {
-        logger.error("Parse from $rdfSource has failed: ${ex.message}")
+        logger.error("${ex.stackTraceToString()}: Parse from $rdfSource has failed")
         return null
     }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -19,23 +19,14 @@
         <target>System.out</target>
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
-                <timestamp>
-                    <fieldName>timestamp</fieldName>
-                </timestamp>
                 <loggerName/>
                 <logLevel>
                     <fieldName>severity</fieldName>
                 </logLevel>
                 <message/>
-                <stackHash/>
-                <stackTrace>
-                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                        <maxDepthPerThrowable>30</maxDepthPerThrowable>
-                        <maxLength>2048</maxLength>
-                        <shortenedClassNameLength>20</shortenedClassNameLength>
-                        <rootCauseFirst>true</rootCauseFirst>
-                    </throwableConverter>
-                </stackTrace>
+                <pattern>
+                    <pattern>{ "serviceContext": { "service": "fdk-dataset-harvester" } }</pattern>
+                </pattern>
             </providers>
         </encoder>
     </appender>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -23,9 +23,11 @@
                 <logLevel>
                     <fieldName>severity</fieldName>
                 </logLevel>
-                <message/>
+                <message>
+                    <fieldName>shortMessage</fieldName>
+                </message>
                 <pattern>
-                    <pattern>{ "serviceContext": { "service": "fdk-dataset-harvester" } }</pattern>
+                    <pattern>{ "message": "%exception%message", "serviceContext": { "service": "fdk-dataset-harvester" } }</pattern>
                 </pattern>
             </providers>
         </encoder>


### PR DESCRIPTION
Eksempel på feilmelding:
```
java.net.MalformedURLException: no protocol: jdlksd.nsd
	at java.base/java.net.URL.<init>(URL.java:672)
	at java.base/java.net.URL.<init>(URL.java:568)
	at java.base/java.net.URL.<init>(URL.java:515)
	at no.digdir.informasjonsforvaltning.fdk_dataset_harvester.adapter.DatasetAdapter.getDatasets(DatasetAdapter.kt:18)
	at no.digdir.informasjonsforvaltning.fdk_dataset_harvester.harvester.DatasetHarvester.harvestDatasetCatalog(DatasetHarvester.kt:36)
	at no.digdir.informasjonsforvaltning.fdk_dataset_harvester.harvester.HarvesterActivity$initiateHarvest$harvest$1$1$2$1.invokeSuspend(HarvesterActivity.kt:48)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
: Error when harvesting from jdlksd.nsd
```
Som vil resultere i at den vil propagere videre til Error reporting i GCP
ref:
https://cloud.google.com/error-reporting/docs/formatting-error-messages#json_representation
https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent