### PR TITLE
chore: update jena

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
         <maven.exec.skip>false</maven.exec.skip>
         <!--end standard properties-->
 
-        <kotlin.version>1.9.23</kotlin.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
-        <jena.version>4.10.0</jena.version>
+        <kotlin.version>1.9.24</kotlin.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
+        <jena.version>5.0.0</jena.version>
 
     </properties>
 
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1</version>
         </dependency>
 
         <!-- RDF dependencies -->
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -179,26 +179,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.basedir}/src/main/kotlin</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterTest.kt
+++ b/src/test/kotlin/no/digdir/informasjonsforvaltning/fdk_dataset_harvester/harvester/HarvesterTest.kt
@@ -281,8 +281,8 @@ class HarvesterTest {
             changedCatalogs=listOf(FdkIdAndUri(fdkId= CATALOG_ID_4, uri="http://example.org/EUCatalog")),
             changedResources = listOf(
                 FdkIdAndUri(fdkId="f1e8443d-910f-3838-87e3-2b5e7ee307a6", uri="http://example.org/budget-2020"),
-                FdkIdAndUri(fdkId="ca883493-7848-3116-8e1a-2b2e610a0fc1", uri="http://example.org/budget-2018"),
                 FdkIdAndUri(fdkId="51704c08-c174-393d-add5-348d3b304aeb", uri="http://example.org/budget-2019"),
+                FdkIdAndUri(fdkId="ca883493-7848-3116-8e1a-2b2e610a0fc1", uri="http://example.org/budget-2018"),
                 FdkIdAndUri(fdkId="ad115f63-9edc-30dc-ab81-f6866e0631ea", uri="http://example.org/budget"))
         )
 


### PR DESCRIPTION
fjerna også `build-helper-maven-plugin`, å deklarere kotlin-mappa som egen kildelokasjon via den var nødvendig før, men går tydeligvis bra nå.

Blir kanskje problematisk uten den for de som har både java og kotlin i samme prosjekt