### PR TITLE
Add `gh_environment` line to workflows

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -14,6 +14,7 @@ jobs:
       java_version: '17'
       coverage_file_path: ./target/site/jacoco/jacoco.xml
       environment: prod
+      gh_environment: prod
     secrets:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -25,6 +26,7 @@ jobs:
     with:
       app_name: fdk-dataset-harvester
       environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +40,7 @@ jobs:
     with:
       app_name: fdk-dataset-harvester
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -16,6 +16,7 @@ jobs:
       java_version: '17'
       coverage_file_path: ./target/site/jacoco/jacoco.xml
       environment: staging
+      gh_environment: staging
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -28,6 +29,7 @@ jobs:
     with:
       app_name: fdk-dataset-harvester
       environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `gh_environment: <env>` after each `environment: <env>` line in key workflows.